### PR TITLE
avoid to load base url if wrapper.vastAdTagURI is empty

### DIFF
--- a/lib/VAST.js
+++ b/lib/VAST.js
@@ -288,7 +288,7 @@ VAST.prototype.resolveWrappers = function resolveWrappers(/*maxRedirects, callba
     }
 
     return nodeifyPromise(LiePromise.all(this.map('wrappers', function requestVAST(wrapper) {
-        if (typeof(wrapper.vastAdTagURI) != 'string' || !wrapper.vastAdTagURI.length) {
+        if (typeof(wrapper.vastAdTagURI) !== 'string' || !wrapper.vastAdTagURI.length) {
             throw new Error('Empty Wrapper VAST URL');
         }
         return LiePromise.resolve(request.get(wrapper.vastAdTagURI))

--- a/lib/VAST.js
+++ b/lib/VAST.js
@@ -288,6 +288,9 @@ VAST.prototype.resolveWrappers = function resolveWrappers(/*maxRedirects, callba
     }
 
     return nodeifyPromise(LiePromise.all(this.map('wrappers', function requestVAST(wrapper) {
+        if (typeof(wrapper.vastAdTagURI) != 'string' || !wrapper.vastAdTagURI.length) {
+            throw new Error('Empty Wrapper VAST URL');
+        }
         return LiePromise.resolve(request.get(wrapper.vastAdTagURI))
             .then(function makeVAST(response) {
                 return {

--- a/test/helpers/vast_2.0--wrapper--empty.xml
+++ b/test/helpers/vast_2.0--wrapper--empty.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VAST version="2.0">
+ <Ad id="nodelivery">
+  <Wrapper>
+   <AdSystem>Any</AdSystem>
+   <VASTAdTagURI></VASTAdTagURI>
+  </Wrapper>
+ </Ad>
+</VAST>

--- a/test/spec/vast.ut.js
+++ b/test/spec/vast.ut.js
@@ -1304,6 +1304,25 @@ describe('VAST', function() {
                     });
                 });
 
+                describe('and the wrapper is empty', function() {
+                    var vastXML, vast;
+
+                    beforeEach(function(done) {
+                        vastXML = require('fs').readFileSync(require.resolve('../helpers/vast_2.0--wrapper--empty.xml')).toString();
+                        vast = new VAST(VAST.pojoFromXML(vastXML));
+
+                        LiePromise.resolve().then(done);
+                    });
+
+                    it('should throw an Error', function() {
+                        expect(function() {
+                            vast.resolveWrappers();
+                        }).toThrow(new Error(
+                            'Empty Wrapper VAST URL'
+                        ));
+                    });
+                });
+
                 describe('if maxRedirects is specified', function() {
                     function wait(time) {
                         return new LiePromise(function(resolve) {


### PR DESCRIPTION
When a VAST wrapper is served with an empty vastAdTagURI, i.e.:

```
<VAST version="2.0">
 <Ad id="nodelivery">
  <Wrapper>
   <AdSystem>Any</AdSystem>
   <VASTAdTagURI></VASTAdTagURI>
  </Wrapper>
 </Ad>
</VAST>

```
the base URL of the webpage is loaded instead. This patch could probably fix it - maybe the throw has to be catched somewhere ... otherwise it will be climb up into the users code.