### PR TITLE
allow to set withCredentials in options

### DIFF
--- a/lib/VAST.js
+++ b/lib/VAST.js
@@ -436,8 +436,9 @@ VAST.fetch = function fetch(uri/*, options, callback*/) {
     var callback = typeof arguments[2] === 'function' ? arguments[2] : arguments[1];
 
     var VAST = this;
+    var req  = request.get(uri).set(options.headers || {});
 
-    return nodeifyPromise(LiePromise.resolve(request.get(uri).set(options.headers || {}))
+    return nodeifyPromise(LiePromise.resolve(options.withCredentials ? req.withCredentials() : req)
         .then(function makeVAST(response) {
             var vast = new VAST(VAST.pojoFromXML(response.text));
 

--- a/test/spec/vast.ut.js
+++ b/test/spec/vast.ut.js
@@ -81,6 +81,9 @@ describe('VAST', function() {
                             },
                             set: jasmine.createSpy('req.set()').and.callFake(function() {
                                 return this;
+                            }),
+                            withCredentials: jasmine.createSpy('req.withCredentials()').and.callFake(function() {
+                                return this;
                             })
                         };
 
@@ -187,6 +190,16 @@ describe('VAST', function() {
                     it('should make a request with the provided headers', function() {
                         expect(request.get).toHaveBeenCalledWith(uri);
                         expect(requestDeferreds[uri].request.set).toHaveBeenCalledWith({ 'API-Key': 'foobar', Accept: 'application/json' });
+                    });
+                });
+
+                describe('if options.withCredentials is provided', function() {
+                    beforeEach(function() {
+                        VAST.fetch(uri, { withCredentials: true });
+                    });
+
+                    it('should call withCredentials of request', function() {
+                        expect(requestDeferreds[uri].request.withCredentials).toHaveBeenCalledWith();
                     });
                 });
 


### PR DESCRIPTION
This could be a fix for [https://github.com/cinema6/vast-player/issues/2](Issue 2 of vast_player). The player could then be started with:

```
var player = new VASTPlayer(document.getElementById('container'), {
    vast: {
        withCredentials: true
    }
});
```