### PR TITLE
Tolerate empty <Creative/> tags when decoding from XML.

### DIFF
--- a/lib/pojo_from_xml.js
+++ b/lib/pojo_from_xml.js
@@ -205,13 +205,15 @@ module.exports = function pojoFromXML(xml) {
                             return 'nonLinear';
                         }
                     }());
+                    
+                    if (!type) return null;
 
                     return extend({
                         id: creative.attributes.id,
                         sequence: numberify(creative.attributes.sequence),
                         adID: creative.attributes.AdID
                     }, creativeParsers[type](creative));
-                })
+                }).filter(function(creative) { return !!creative; })
             }, adParsers[type](ad));
         })
     }, true);


### PR DESCRIPTION
This PR lets pojoFromXML() ignore Creative tags without a `type`.

For an example seen in the wild:
In [Google's collection of sample VAST/VPAID tags](https://developers.google.com/interactive-media-ads/docs/sdks/html5/tags), the item "Single VPAID 2.0 Linear" wraps a [second static tag](https://storage.googleapis.com/gvabox/external_sample/vpaid2jslinear.xml), which contains one valid creative tag, and one empty one - which causes pojoFromXML() to throw an exception "creativeParsers[type] is not a function", as `type` is undefined.